### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/app/build/intermediates/bundle_manifest/debug/processDebugManifest/bundle-manifest/AndroidManifest.xml
+++ b/app/build/intermediates/bundle_manifest/debug/processDebugManifest/bundle-manifest/AndroidManifest.xml
@@ -24,9 +24,9 @@
 
     <application
         android:name="com.ostep.operation.App"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:appComponentFactory="android.support.v4.app.CoreComponentFactory"
-        android:debuggable="true"
+        android:debuggable="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher"


### PR DESCRIPTION
For allow:Debuggable: If an application is marked as debuggable then an attacker can access the application data by assuming the privileges of that application or can run arbitrary code under that application permission. 
For allow:Backup: This is considered a security issue because people could backup your app via ADB and then get private data of your app into their PC.
Always set to false wrt to security.